### PR TITLE
Custom providers support

### DIFF
--- a/mimesis_factory.py
+++ b/mimesis_factory.py
@@ -51,7 +51,9 @@ class MimesisField(declarations.BaseDeclaration):
         kwargs.update(self.kwargs)
         kwargs.update(extra)
 
-        mimesis = self._get_cached_instance(locale=self.locale)
+        providers = step.builder.factory_meta.declarations.get('providers')
+        mimesis = self._get_cached_instance(locale=self.locale,
+                                            providers=providers)
         return mimesis(self.field, **kwargs)
 
     @classmethod
@@ -70,11 +72,12 @@ class MimesisField(declarations.BaseDeclaration):
             cls._DEFAULT_LOCALE = old_locale
 
     @classmethod
-    def _get_cached_instance(cls, locale=None):
+    def _get_cached_instance(cls, locale=None, providers=None):
         if locale is None:
             locale = cls._DEFAULT_LOCALE
 
-        if locale not in cls._CACHED_INSTANCES:
-            cls._CACHED_INSTANCES[locale] = Field(locale)
+        key = (locale, providers)
+        if key not in cls._CACHED_INSTANCES:
+            cls._CACHED_INSTANCES[key] = Field(locale, providers=providers)
 
-        return cls._CACHED_INSTANCES[locale]
+        return cls._CACHED_INSTANCES[key]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+import factory
+import pytest
+from mimesis import builtins
+from mimesis.enums import Gender
+from mimesis.exceptions import UnsupportedField
+from pytest_factoryboy import register
+
+from mimesis_factory import MimesisField
+
+
+class Guest(object):
+    def __init__(self, full_name, patronymic):
+        self.full_name = full_name
+        self.patronymic = patronymic
+
+
+@register
+class FactoryWithNoProviders(factory.Factory):
+    class Meta:
+        model = Guest
+
+    full_name = MimesisField('full_name', gender=Gender.FEMALE)
+    patronymic = MimesisField('patronymic')
+
+
+@register
+class FactoryWithProviders(factory.Factory):
+    class Meta:
+        model = Guest
+
+    class Params:
+        providers = (builtins.RussiaSpecProvider,)
+
+    full_name = MimesisField('full_name', gender=Gender.FEMALE)
+    patronymic = MimesisField('patronymic')
+
+
+def test_factory_with_not_extended_providers(factory_with_no_providers):
+    with pytest.raises(UnsupportedField):
+        factory_with_no_providers()
+
+
+def test_factory_with_extended_providers(factory_with_providers):
+    guest = factory_with_providers()
+    assert isinstance(guest, Guest)


### PR DESCRIPTION
Add support for custom providers. Providers must be set in Params options.
Fix #20 