### PR TITLE
reflect mimesis module renaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 
 python:
-  - 3.5
   - 3.6
+  - 3.7
 
 install:
   - pip install poetry

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - 3.6
-  - 3.7
 
 install:
   - pip install poetry

--- a/mimesis_factory.py
+++ b/mimesis_factory.py
@@ -3,7 +3,7 @@
 import contextlib
 
 from factory import declarations
-from mimesis import config
+from mimesis import locales
 from mimesis.schema import Field
 
 
@@ -19,7 +19,7 @@ class MimesisField(declarations.BaseDeclaration):
     """
 
     _CACHED_INSTANCES = {}
-    _DEFAULT_LOCALE = config.DEFAULT_LOCALE
+    _DEFAULT_LOCALE = locales.DEFAULT_LOCALE
 
     def __init__(self, field, locale=None, **kwargs):
         """


### PR DESCRIPTION
As stated in https://github.com/lk-geimfari/mimesis/blob/master/CHANGELOG.rst#version-300:
...
- Renamed module ``config.py`` to ``locales.py``
...

this should update PR #49 